### PR TITLE
Showing line numbers next to code blocks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,18 +4,33 @@
     "bootstrap": "3.3.7",
     "bootswatch": "3.3.7",
     "font-awesome": "4.7.0",
+    "highlightjs-line-numbers.js": "1.1.0",
     "jquery": "3.2.1",
     "moment": "2.18.1"
   },
   "overrides": {
     "bootstrap": {
-      "main": ["less/**", "fonts/*", "js/*"]
+      "main": [
+        "less/**",
+        "fonts/*",
+        "js/*"
+      ]
     },
     "bootswatch": {
-      "main": ["**/*.less"]
+      "main": [
+        "**/*.less"
+      ]
     },
     "font-awesome": {
-      "main": ["less/*", "fonts/*"]
+      "main": [
+        "less/*",
+        "fonts/*"
+      ]
+    },
+    "highlightjs-line-numbers.js": {
+      "main": [
+        "src/highlightjs-line-numbers.js"
+      ]
     }
   }
 }

--- a/gulp/config.coffee
+++ b/gulp/config.coffee
@@ -12,7 +12,6 @@ config =
     "#{paths.static.ext}/bootstrap/js/collapse.js"
     "#{paths.static.ext}/bootstrap/js/dropdown.js"
     "#{paths.static.ext}/bootstrap/js/tooltip.js"
-    "#{paths.static.ext}/highlightjs-line-numbers.js/src/highlightjs-line-numbers.js"
   ]
   style: [
     "#{paths.src.style}/style.less"
@@ -20,6 +19,7 @@ config =
   script: [
     "#{paths.src.script}/**/*.coffee"
     "#{paths.src.script}/**/*.js"
+    "#{paths.static.ext}/highlightjs-line-numbers.js/src/highlightjs-line-numbers.js"
   ]
 
 

--- a/gulp/config.coffee
+++ b/gulp/config.coffee
@@ -12,6 +12,7 @@ config =
     "#{paths.static.ext}/bootstrap/js/collapse.js"
     "#{paths.static.ext}/bootstrap/js/dropdown.js"
     "#{paths.static.ext}/bootstrap/js/tooltip.js"
+    "#{paths.static.ext}/highlightjs-line-numbers.js/src/highlightjs-line-numbers.js"
   ]
   style: [
     "#{paths.src.style}/style.less"

--- a/main/static/src/script/post.js
+++ b/main/static/src/script/post.js
@@ -1,5 +1,6 @@
 function initPostView() {
   $('pre code').each(function (i, block) {
     hljs.highlightBlock(block);
+    hljs.lineNumbersBlock(block);
   });
 }

--- a/main/static/src/style/highlight/line-numbers.less
+++ b/main/static/src/style/highlight/line-numbers.less
@@ -1,0 +1,6 @@
+.hljs-line-numbers {
+  border-right: 1px solid #ccc;
+  color: #999;
+  text-align: right;
+  user-select: none;
+}

--- a/main/static/src/style/style.less
+++ b/main/static/src/style/style.less
@@ -5,6 +5,7 @@
 @import "../../ext/bootswatch/flatly/bootswatch";
 
 @import (less) "highlight/default.css";
+@import "highlight/line-numbers";
 
 @import "base";
 @import "variables";


### PR DESCRIPTION
@lipis It seems to be ready but I get the exception: `highlight.js not detected!` I guess the problem exists because we hacked in the loading of `highlight.pack.js` (https://github.com/welovecoding/vote4code/pull/14) and `highlightjs-line-numbers.js` must be included in `scripts` after the original `highlight.pack.js` but I don't know how to do it because including `highlight.pack.js` is different from the original gae-init way.